### PR TITLE
substitute placeholders for "this" variables

### DIFF
--- a/src/main/java/representer/normalizer/PlaceholderNormalizer.java
+++ b/src/main/java/representer/normalizer/PlaceholderNormalizer.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.NameExpr;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 
@@ -36,6 +37,13 @@ public class PlaceholderNormalizer extends VoidVisitorAdapter<String> {
 
     @Override
     public void visit(NameExpr n, String arg) {
+        final String name = n.getNameAsString();
+        n.setName(mapper.getPlaceholder(name));
+        super.visit(n, arg);
+    }
+
+    @Override
+    public void visit(FieldAccessExpr n, String arg) {
         final String name = n.getNameAsString();
         n.setName(mapper.getPlaceholder(name));
         super.visit(n, arg);


### PR DESCRIPTION
This is a proposal to fix #7 

At the moment the result is the follow, starting from this:

```
final class BaseConverter {
   
    ...
    ... 
    private final int numeral;

    BaseConverter(final int originalBase, final int[] originalDigits) {
        validateInputs(originalBase, originalDigits);
        this.numeral = computeNumeral(originalBase, originalDigits);
    }
   ...
   ...
}
```
substitute with

```
final class PLACEHOLDER_1 {

   ...
   ...
    private final int numeral;

    PLACEHOLDER_1(final int PLACEHOLDER_2, final int[] PLACEHOLDER_3) {
        validateInputs(PLACEHOLDER_2, PLACEHOLDER_3);
        this.PLACEHOLDER_4 = computeNumeral(PLACEHOLDER_2, PLACEHOLDER_3);
    }

   ...
   ...
}

```

This solution considers that

`numeral = computeNumeral(originalBase, originalDigits);`

and

`this.numeral = computeNumeral(originalBase, originalDigits);`

are not the same and so produces a difference into the class representation

I am not sure if this solution can be good or if we have to consider `this.numeral` the same as `numeral`

so, to give an example example, substitute

`this.numeral = computeNumeral(originalBase, originalDigits);`

with

`PLACEHOLDER_4 = computeNumeral(PLACEHOLDER_2, PLACEHOLDER_3);`

considering PLACEHOLDER_4 the placeholder for `numeral` variable.

I need a discussion with @exercism/java 



