### PR TITLE
remove javadoc comments from representation #17

### DIFF
--- a/src/main/java/representer/normalizer/CommentNormalizer.java
+++ b/src/main/java/representer/normalizer/CommentNormalizer.java
@@ -3,12 +3,14 @@ package representer.normalizer;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.comments.BlockComment;
 import com.github.javaparser.ast.comments.LineComment;
+import com.github.javaparser.ast.comments.JavadocComment;
+
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 
 public class CommentNormalizer extends ModifierVisitor<String> {
 
     /**
-     * Remove nodes of type BlockComment
+     * Remove nodes of type LineComment
      */
     @Override
     public Node visit(LineComment n, String arg) {
@@ -20,6 +22,14 @@ public class CommentNormalizer extends ModifierVisitor<String> {
      */
     @Override
     public Node visit(BlockComment n, String arg) {
+        return null;
+    }
+
+    /**
+     * Remove nodes of type JavadocComment
+     */
+    @Override
+    public Node visit(JavadocComment n, String arg) {
         return null;
     }
 }

--- a/src/test/resources/exercises/alphametics/representation
+++ b/src/test/resources/exercises/alphametics/representation
@@ -19,9 +19,6 @@ public class PLACEHOLDER_1
         return PLACEHOLDER_11.get().orElseThrow(UnsolvablePuzzleException::new);
     }
 
-    /**
-     * Returns the list of distinct characters in this alphametic puzzle.
-     */
     private List<PLACEHOLDER_7> PLACEHOLDER_10() 
     {
         Set<Character> PLACEHOLDER_12 = new LinkedHashSet<>();
@@ -80,18 +77,11 @@ public class PLACEHOLDER_1
             return Optional.ofNullable(PLACEHOLDER_20);
         }
 
-        /**
-         * Returns true if the mapping letters to digits using {@code letterToDigit} will result in having zero as a
-         * leading digit.
-         */
         private boolean PLACEHOLDER_23(Map<Character, Integer> PLACEHOLDER_34) 
         {
             return PLACEHOLDER_36.keySet().stream().filter(PLACEHOLDER_35 -> PLACEHOLDER_36.get(PLACEHOLDER_35) == 0).filter(PLACEHOLDER_32 -> PLACEHOLDER_3.charAt(0) == PLACEHOLDER_32 || PLACEHOLDER_2.stream().map(PLACEHOLDER_14 -> PLACEHOLDER_15.charAt(0)).anyMatch(PLACEHOLDER_33 -> PLACEHOLDER_33 == PLACEHOLDER_32)).count() == 1;
         }
 
-        /**
-         * Returns true if the {@code letterToDigit} solves the alphametic puzzle.
-         */
         private boolean PLACEHOLDER_26(Map<Character, Integer> PLACEHOLDER_34) 
         {
             long PLACEHOLDER_37 = PLACEHOLDER_2.stream().mapToLong(PLACEHOLDER_14 -> PLACEHOLDER_38(PLACEHOLDER_36, PLACEHOLDER_15)).sum();
@@ -99,9 +89,6 @@ public class PLACEHOLDER_1
             return PLACEHOLDER_37 == PLACEHOLDER_39;
         }
 
-        /**
-         * Returns the long value of {@code word}, mapped using {@code letterToDigit}.
-         */
         private long PLACEHOLDER_38(Map<Character, Integer> PLACEHOLDER_34, String PLACEHOLDER_14) 
         {
             StringBuilder PLACEHOLDER_40 = new StringBuilder();


### PR DESCRIPTION
Hi, 
- added a handler to remove Javadoc comments
- this was exposed by alphametics solution that contained JavaDoc, so removed those from the representation.